### PR TITLE
fail build on errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.smoope.utils</groupId>
+    <groupId>com.smoope.utils.kenwdelong</groupId>
     <artifactId>j2objc-maven-plugin</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.3a</version>
     <packaging>maven-plugin</packaging>
     <name>Maven plugin for J2ObjC library</name>
     <description>In addition to standard J2ObjC conversion, this plugin supports dependencies conversion
@@ -22,25 +22,9 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git://github.com/smoope/j2objc-maven-plugin.git</connection>
-        <url>https://github.com/smoope/j2objc-maven-plugin</url>
+        <connection>scm:git:git://github.com/kenwdelong/j2objc-maven-plugin.git</connection>
+        <url>https://github.com/kenwdelong/j2objc-maven-plugin</url>
     </scm>
-    <developers>
-        <developer>
-            <name>Victor Mosin</name>
-            <email>victor@smoope.com</email>
-            <organization>Smoope</organization>
-            <organizationUrl>https://www.smoope.com</organizationUrl>
-        </developer>
-    </developers>
-    <ciManagement>
-        <system>travis-ci</system>
-        <url>https://travis-ci.org/smoope/j2objc-maven-plugin</url>
-    </ciManagement>
-    <issueManagement>
-        <system>Github Issues</system>
-        <url>https://github.com/smoope/j2objc-maven-plugin/issues</url>
-    </issueManagement>
 
     <properties>
         <java.version>1.7</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.smoope.utils.kenwdelong</groupId>
+    <groupId>com.smoope.utils</groupId>
     <artifactId>j2objc-maven-plugin</artifactId>
-    <version>1.1.3a</version>
+    <version>1.1.3-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <name>Maven plugin for J2ObjC library</name>
     <description>In addition to standard J2ObjC conversion, this plugin supports dependencies conversion
@@ -22,9 +22,25 @@
         </license>
     </licenses>
     <scm>
-        <connection>scm:git:git://github.com/kenwdelong/j2objc-maven-plugin.git</connection>
-        <url>https://github.com/kenwdelong/j2objc-maven-plugin</url>
+        <connection>scm:git:git://github.com/smoope/j2objc-maven-plugin.git</connection>
+        <url>https://github.com/smoope/j2objc-maven-plugin</url>
     </scm>
+    <developers>
+        <developer>
+            <name>Victor Mosin</name>
+            <email>victor@smoope.com</email>
+            <organization>Smoope</organization>
+            <organizationUrl>https://www.smoope.com</organizationUrl>
+        </developer>
+    </developers>
+    <ciManagement>
+        <system>travis-ci</system>
+        <url>https://travis-ci.org/smoope/j2objc-maven-plugin</url>
+    </ciManagement>
+    <issueManagement>
+        <system>Github Issues</system>
+        <url>https://github.com/smoope/j2objc-maven-plugin/issues</url>
+    </issueManagement>
 
     <properties>
         <java.version>1.7</java.version>

--- a/src/main/java/com/smoope/utils/J2ObjCConverterMojo.java
+++ b/src/main/java/com/smoope/utils/J2ObjCConverterMojo.java
@@ -213,8 +213,10 @@ public class J2ObjCConverterMojo extends AbstractMojo {
             }
         } catch (DependencyResolutionException e) {
             getLog().error(e);
+            throw new MojoExecutionException("Build error - dependency resolution failed", e);
         } catch (IOException e) {
             getLog().error(e);
+            throw new MojoExecutionException("Build error - IO error", e);
         }
     }
 

--- a/src/main/java/com/smoope/utils/J2ObjCConverterMojo.java
+++ b/src/main/java/com/smoope/utils/J2ObjCConverterMojo.java
@@ -218,9 +218,10 @@ public class J2ObjCConverterMojo extends AbstractMojo {
         }
     }
 
-    private void executeCommand(final String command) {
+    private void executeCommand(final String command) throws MojoFailureException, MojoExecutionException {
         getLog().info(String.format("Executing: %s", command));
 
+        boolean hasErrors = false;
         try {
             Process process = Runtime.getRuntime().exec(command);
             BufferedReader result = new BufferedReader(new
@@ -234,11 +235,14 @@ public class J2ObjCConverterMojo extends AbstractMojo {
             }
             while ((output = errors.readLine()) != null) {
                 getLog().error(output);
+                hasErrors = true;
             }
 
         }  catch (IOException e) {
             getLog().error(e);
+            throw new MojoExecutionException("j2objc failed with exception", e);            
         }
+        if(hasErrors) throw new MojoFailureException("j2objc translator had errors - check log");
     }
 
     private List<String> getSourceFiles(final File sourcesDirectory, final File parentDirectory) {


### PR DESCRIPTION
I found that my translation step was failing (I had included Java classes that had no translation, like LocalDateTime) but my builds were happily succeeding, erroneously.  I made these small changes to the Mojo (ignore the pom changes) to cause Maven to register a build failure if the j2objc command execution fails.  I think it would be good to include something like this; it's not sustainable to check the log files manually after every Jenkins build to make sure the translation step succeeded.